### PR TITLE
Wire startpage home page from real DOM

### DIFF
--- a/src/components/email/email-popup/variants/startpage.ts
+++ b/src/components/email/email-popup/variants/startpage.ts
@@ -1,21 +1,25 @@
 import { emailPopupButton } from "..";
 
-// TODO: pick the right anchor element from startpage's header. The search
-// page and the home page have different shells; the selectors here cover
-// the obvious header containers as a starting point.
+// The right-aligned nav container on home is `.nav-app-promo` (a flex row
+// ending in the hamburger button). The helper sets flex styles on the
+// container and inserts the mail button as the first child, putting it to
+// the left of the hamburger.
+//
+// TODO: confirm the same container shows up on the SERP — startpage's
+// SERP HTML hasn't been inspected yet. If it doesn't, fall back to a
+// broader selector or add a SERP-specific case.
 export function addStartpageMailButton() {
-  const settingsDiv = document.querySelector<HTMLElement>(
-    "header .header-right, .nav-right, #header-right"
-  );
+  const settingsDiv = document.querySelector<HTMLElement>(".nav-app-promo");
   if (!settingsDiv) return;
   emailPopupButton(settingsDiv);
 }
 
 export function startpagePopupPosition(emailPopup: HTMLElement) {
-  // TODO: calibrate against real header height once selectors above are
-  // confirmed.
+  // The header (`#home-top-header`) is absolute-positioned, roughly 64px
+  // tall on home. Anchor under the right edge of the nav, just below the
+  // header bottom edge with a few px breathing room.
   emailPopup.style.top = "60px";
-  emailPopup.style.right = "20px";
+  emailPopup.style.right = "60px";
 }
 
 export function startpagePopupStyle(emailPopup: HTMLElement) {

--- a/src/components/general/variants/startpage.ts
+++ b/src/components/general/variants/startpage.ts
@@ -1,10 +1,35 @@
-import { replaceToGoogleLogo } from "..";
+const GOOGLE_LOGO_URL =
+  "https://www.google.com/images/branding/googlelogo/1x/googlelogo_light_color_272x92dp.png";
 
-// TODO: confirm by inspecting startpage.com home + SERP DOM. The selectors
-// below are best-guess placeholders covering both pages.
+const REPLACED_MARKER = "data-sp-logo-replaced";
+
 export function replaceStartpageToGoogleLogo() {
-  const logos = document.querySelectorAll<HTMLImageElement>(
-    'img[alt*="Startpage" i], img[src*="startpage-logo" i], .logo img'
-  );
-  replaceToGoogleLogo(logos);
+  // The home page logo is an inline SVG with class `startpage-logo` inside
+  // the hero. The shared replaceToGoogleLogo helper handles <img>/<source>
+  // and falls back to an inline-styled tiny <img> for other elements — too
+  // small for the hero. Do a targeted swap instead.
+  document
+    .querySelectorAll<SVGSVGElement>(`svg.startpage-logo:not([${REPLACED_MARKER}])`)
+    .forEach((svg) => {
+      const img = document.createElement("img");
+      img.src = GOOGLE_LOGO_URL;
+      img.alt = "Google";
+      img.style.height = "53px";
+      img.style.width = "auto";
+      img.style.objectFit = "contain";
+      img.setAttribute(REPLACED_MARKER, "1");
+      svg.replaceWith(img);
+    });
+
+  // Footer logo (rendered as <img>). Match by src so emotion class churn
+  // doesn't break us.
+  document
+    .querySelectorAll<HTMLImageElement>(
+      `img[src*="startpage-logo"]:not([${REPLACED_MARKER}])`
+    )
+    .forEach((img) => {
+      img.src = GOOGLE_LOGO_URL;
+      img.style.objectFit = "contain";
+      img.setAttribute(REPLACED_MARKER, "1");
+    });
 }

--- a/src/components/head/variants/startpage.ts
+++ b/src/components/head/variants/startpage.ts
@@ -1,7 +1,12 @@
 export function changeStartpageTitle() {
+  // Home title: "Startpage - Private Search Engine. No Tracking. No Search History."
+  // SERP title format hasn't been confirmed — the Startpage replacement
+  // alone covers the common case ("<query> - Startpage").
   const next = document.title
     .replace("Startpage", "Google")
-    .replace("The world's most private search engine - ", "")
-    .replace(" - The world's most private search engine", "");
+    .replace(
+      " - Private Search Engine. No Tracking. No Search History.",
+      ""
+    );
   if (next !== document.title) document.title = next;
 }


### PR DESCRIPTION
## Summary

First pass that takes the startpage scaffold from "renders nothing useful" to a working home page. Selectors come from the real `www.startpage.com` HTML.

| Touched | What landed |
|---|---|
| `general/variants/startpage.ts` | Inline-SVG hero logo (`svg.startpage-logo`) gets replaced with a properly-sized Google logo; footer logo also swapped. Both gated by a `data-sp-logo-replaced` marker so the observer-loop won't re-fire. |
| `email/email-popup/variants/startpage.ts` | `addStartpageMailButton` now selects `.nav-app-promo` (the right-aligned nav row); mail button slots in left of the hamburger. Popup position calibrated to the ~64px header. |
| `head/variants/startpage.ts` | Title rewriter matches the real home title. |

## Still TODO (blocked on HTML I haven't seen yet)

- **SERP layout** (`/sp/search?...`) — no equivalents of `.snippet[data-type]` yet, so video/product thumbnail moves and snippet styling have nothing to bind to.
- **Settings panel injection** (`/do/settings`) — stub still short-circuits; needs the page's container selector.
- **SERP nav** — `.nav-app-promo` is confirmed on home; unconfirmed on SERP. May need a second selector if it's named differently there.

## Test plan

- [x] `bun run build:all` clean
- [ ] Load `dist/chrome` in Brave, visit `www.startpage.com` — hero logo flipped, mail button appears in the header, title rewrites, console clean
- [ ] No regressions on `search.brave.com` or `duckduckgo.com`