### PR TITLE
Google-style theme for Brave, DuckDuckGo, and Startpage SERPs

### DIFF
--- a/src/components/google-theme/index.ts
+++ b/src/components/google-theme/index.ts
@@ -1,0 +1,20 @@
+import { getSite } from "../../utils/functions";
+import { braveGoogleCSS } from "./variants/brave";
+import { duckduckgoGoogleCSS } from "./variants/duckduckgo";
+import { startpageGoogleCSS } from "./variants/startpage";
+
+const STYLE_ID = "google-theme-styles";
+
+const cssBySite = {
+  brave: braveGoogleCSS,
+  duckduckgo: duckduckgoGoogleCSS,
+  startpage: startpageGoogleCSS,
+};
+
+export function applyGoogleTheme() {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = cssBySite[getSite()];
+  document.head.appendChild(style);
+}

--- a/src/components/google-theme/tokens.ts
+++ b/src/components/google-theme/tokens.ts
@@ -1,0 +1,37 @@
+// Design tokens extracted from a live Google SERP (dark mode). Used to
+// drive the per-engine Google-style overrides under variants/.
+
+export const tokens = {
+  color: {
+    bg: "#22242a",
+    text: "#e8e8e8",
+    textMuted: "#bfbfbf",
+    link: "#99c3ff",
+    linkVisited: "#c58af9",
+    cite: "#bdc1c6",
+    siteName: "#e8e8e8",
+    searchBarBg: "#4d5156",
+    searchBarBgHover: "#5f6368",
+    searchBarBgFocused: "#303134",
+    inputText: "#e8eaed",
+    placeholder: "#9aa0a6",
+    cardBorder: "#444746",
+  },
+  font: {
+    body: "Arial, sans-serif",
+    display: "'Google Sans', Arial, sans-serif",
+  },
+  size: {
+    titlePx: 22,
+    titleLineHeightPx: 28,
+    snippetPx: 14,
+    snippetLineHeight: 1.58,
+    sitePx: 14,
+    sitePathPx: 12,
+    inputPx: 16,
+    searchBarHeightPx: 50,
+    searchBarRadiusPx: 26,
+    resultMarginBottomPx: 30,
+    resultMaxWidthPx: 652,
+  },
+} as const;

--- a/src/components/google-theme/variants/brave.ts
+++ b/src/components/google-theme/variants/brave.ts
@@ -1,0 +1,75 @@
+import { tokens } from "../tokens";
+
+const c = tokens.color;
+const f = tokens.font;
+const s = tokens.size;
+
+// Brave Search already uses class names that match Google's own SERP
+// (.RNNXgb for the bar, .snippet[data-type] for results). We override
+// color + typography to enforce Google's exact look in dark mode.
+export const braveGoogleCSS = `
+  /* Search bar pill */
+  .RNNXgb {
+    background: ${c.searchBarBg} !important;
+    border-radius: ${s.searchBarRadiusPx}px !important;
+    min-height: ${s.searchBarHeightPx}px !important;
+    border: 1px solid transparent !important;
+    box-shadow: none !important;
+  }
+  .RNNXgb:hover {
+    background: ${c.searchBarBgHover} !important;
+  }
+  .RNNXgb:focus-within {
+    background: ${c.searchBarBgFocused} !important;
+    box-shadow: 0 4px 12px rgba(23, 23, 23, .9) !important;
+  }
+  .RNNXgb .gLFyf,
+  .RNNXgb textarea,
+  .RNNXgb input[type="text"],
+  .RNNXgb input[type="search"] {
+    font-family: ${f.display} !important;
+    font-size: ${s.inputPx}px !important;
+    color: ${c.inputText} !important;
+    background: transparent !important;
+  }
+
+  /* Result block spacing */
+  .snippet[data-type] {
+    background: transparent !important;
+    border: 1px solid transparent !important;
+    margin-bottom: ${s.resultMarginBottomPx}px !important;
+    max-width: ${s.resultMaxWidthPx}px !important;
+  }
+  /* Title */
+  .snippet[data-type="web"] a[srp-el-jm-ea] .title,
+  .snippet[data-type="web"] a[srp-el-jm-ea] h3,
+  .snippet[data-type="web"] .title {
+    font-family: ${f.display} !important;
+    font-size: ${s.titlePx}px !important;
+    font-weight: 400 !important;
+    line-height: ${s.titleLineHeightPx}px !important;
+    color: ${c.link} !important;
+  }
+  .snippet[data-type="web"] a:visited .title,
+  .snippet[data-type="web"] a:visited h3 {
+    color: ${c.linkVisited} !important;
+  }
+  /* Cite / URL row */
+  .snippet[data-type] .url,
+  .snippet[data-type] cite {
+    font-family: ${f.body} !important;
+    font-size: ${s.sitePathPx}px !important;
+    color: ${c.cite} !important;
+    font-style: normal !important;
+  }
+  /* Snippet description */
+  .snippet-description {
+    font-family: ${f.body} !important;
+    font-size: ${s.snippetPx}px !important;
+    line-height: ${s.snippetLineHeight} !important;
+    color: ${c.textMuted} !important;
+  }
+  .snippet-description span {
+    opacity: 1 !important;
+  }
+`;

--- a/src/components/google-theme/variants/duckduckgo.ts
+++ b/src/components/google-theme/variants/duckduckgo.ts
@@ -1,0 +1,103 @@
+import { tokens } from "../tokens";
+
+const c = tokens.color;
+const f = tokens.font;
+const s = tokens.size;
+
+// DuckDuckGo ships React with hashed class names that change between
+// builds. Use stable data-* attributes for everything; the only
+// class-based selector we touch is the article wrapper via
+// [data-testid="result"].
+export const duckduckgoGoogleCSS = `
+  /* Page background to match Google */
+  body,
+  body main {
+    background: ${c.bg} !important;
+    color: ${c.text} !important;
+  }
+
+  /* Search bar — DDG renders the input via a form with a known data-testid.
+     Fallback to input[name="q"] for safety. */
+  form[role="search"],
+  form[data-testid="search"] {
+    background: ${c.searchBarBg} !important;
+    border-radius: ${s.searchBarRadiusPx}px !important;
+    min-height: ${s.searchBarHeightPx}px !important;
+    border: 1px solid transparent !important;
+    box-shadow: none !important;
+    padding: 0 16px !important;
+    display: flex !important;
+    align-items: center !important;
+  }
+  form[role="search"]:hover,
+  form[data-testid="search"]:hover {
+    background: ${c.searchBarBgHover} !important;
+  }
+  form[role="search"]:focus-within,
+  form[data-testid="search"]:focus-within {
+    background: ${c.searchBarBgFocused} !important;
+    box-shadow: 0 4px 12px rgba(23, 23, 23, .9) !important;
+  }
+  input[name="q"] {
+    font-family: ${f.display} !important;
+    font-size: ${s.inputPx}px !important;
+    color: ${c.inputText} !important;
+    background: transparent !important;
+    border: none !important;
+  }
+
+  /* Result block — strip the side image and drop the indent that comes with it */
+  li[data-layout="organic"] {
+    padding-inline-start: 0 !important;
+    margin-bottom: ${s.resultMarginBottomPx}px !important;
+    max-width: ${s.resultMaxWidthPx}px !important;
+    background: transparent !important;
+  }
+  li[data-layout="organic"] > a[data-srp-el-jm-ea] {
+    display: none !important;
+  }
+  [data-testid="result"] {
+    background: transparent !important;
+    padding: 0 !important;
+  }
+  /* Hide the 3-dot context menu trigger */
+  [data-testid="result"] button[aria-haspopup="menu"] {
+    display: none !important;
+  }
+
+  /* Title */
+  [data-testid="result-title-a"],
+  [data-testid="result-title-a"] span,
+  [data-testid="result-title-a"] h2 {
+    font-family: ${f.display} !important;
+    font-size: ${s.titlePx}px !important;
+    font-weight: 400 !important;
+    line-height: ${s.titleLineHeightPx}px !important;
+    color: ${c.link} !important;
+  }
+  [data-testid="result-title-a"]:visited,
+  [data-testid="result-title-a"]:visited span,
+  [data-testid="result-title-a"]:visited h2 {
+    color: ${c.linkVisited} !important;
+  }
+
+  /* URL row (site icon + name + path) */
+  [data-testid="result-extras-site-search-link"] {
+    margin-right: 8px !important;
+  }
+  [data-testid="result-extras-url-link"],
+  [data-testid="result-extras-url-link"] * {
+    font-family: ${f.body} !important;
+    font-size: ${s.sitePathPx}px !important;
+    color: ${c.cite} !important;
+  }
+
+  /* Snippet */
+  [data-result="snippet"],
+  [data-result="snippet"] * {
+    font-family: ${f.body} !important;
+    font-size: ${s.snippetPx}px !important;
+    line-height: ${s.snippetLineHeight} !important;
+    color: ${c.textMuted} !important;
+  }
+`;

--- a/src/components/google-theme/variants/startpage.ts
+++ b/src/components/google-theme/variants/startpage.ts
@@ -92,4 +92,90 @@ export const startpageGoogleCSS = `
   .anonymous-view-link {
     display: none !important;
   }
+
+  /* ---------- SERP header chrome ---------- */
+  /* On the SERP, Startpage wraps logo + search bar + tabs in a top <header>.
+     Force the same dark background as the body so the header doesn't sit
+     in its own off-color band. */
+  body > header,
+  .header-inner-container,
+  .mobile-nav,
+  .top-nav-container {
+    background: ${c.bg} !important;
+  }
+  body > header {
+    border-bottom: 1px solid ${c.cardBorder} !important;
+  }
+
+  /* Category tabs (All / Images / Videos / News / Shopping / Maps).
+     Match Google's underlined tab style. */
+  .inline-nav {
+    background: ${c.bg} !important;
+    border-bottom: 1px solid ${c.cardBorder} !important;
+  }
+  .inline-nav .categories {
+    display: flex !important;
+  }
+  .inline-nav .vertical-link-container {
+    padding: 0 !important;
+  }
+  .inline-nav .header-nav-item-button {
+    padding: 0 12px !important;
+    background: transparent !important;
+  }
+  .inline-nav .header-nav-item {
+    min-height: 48px !important;
+    display: flex !important;
+    align-items: flex-end !important;
+    padding-bottom: 8px !important;
+    border-bottom: 3px solid transparent !important;
+  }
+  .inline-nav .header-nav-item-text {
+    font-family: ${f.display} !important;
+    font-size: ${s.sitePx}px !important;
+    font-weight: 500 !important;
+    color: #80868b !important;
+    text-transform: none !important;
+  }
+  .inline-nav .header-nav-item:hover .header-nav-item-text {
+    color: ${c.text} !important;
+  }
+
+  /* Google has no "Private Search" affordance — hide Startpage's pill. */
+  .private-search-dropdown {
+    display: none !important;
+  }
+
+  /* ---------- Search-suggestion dropdown ---------- */
+  /* The suggestions render inside .search-form-container as a list of
+     .search-suggestion rows. Match Google's autocomplete dropdown look. */
+  .suggested-search-container {
+    background: ${c.searchBarBgFocused} !important;
+    border-radius: 0 0 ${s.searchBarRadiusPx}px ${s.searchBarRadiusPx}px !important;
+    box-shadow: 0 4px 12px rgba(23, 23, 23, .9) !important;
+  }
+  .search-suggestion {
+    background: transparent !important;
+    padding: 8px 16px !important;
+  }
+  .search-suggestion p {
+    font-family: ${f.display} !important;
+    font-size: ${s.inputPx}px !important;
+    color: ${c.text} !important;
+    margin: 0 !important;
+  }
+  .search-suggestion:hover,
+  .search-suggestion[aria-selected="true"] {
+    background: ${c.cardBorder} !important;
+  }
+
+  /* ---------- Body font ---------- */
+  /* Default to Arial across the page so non-result chrome matches the
+     Google body typography. */
+  body {
+    font-family: ${f.body} !important;
+  }
+  h1, h2, h3, h4 {
+    font-family: ${f.display} !important;
+  }
 `;

--- a/src/components/google-theme/variants/startpage.ts
+++ b/src/components/google-theme/variants/startpage.ts
@@ -4,124 +4,124 @@ const c = tokens.color;
 const f = tokens.font;
 const s = tokens.size;
 
-// Startpage uses emotion-generated css-* class names but ships stable
-// semantic classes alongside them (.result, .wgl-title, .wgl-site-title,
-// .wgl-display-url, .description). The search form has .search-form-container
-// and input.search-form-input.
+// Startpage uses emotion CSS-in-JS. Two things to know:
+//   1. The `css-XXXX` classes are content hashes — they CAN change between
+//      builds, so don't anchor on them.
+//   2. Emotion also emits stable "label" classes alongside (e.g. e1fgh61o0
+//      on <header>, eu3pp1u0 on <footer>, e1vne5t50 on the search box,
+//      e6rco0f0 on <main>). Those derive from the component source, so
+//      they're stable across builds. Use them, plus the semantic classes
+//      that the app ships (.header-inner-container, .search-form-container,
+//      .inline-nav, .result, .wgl-title, etc.).
+//
+// The header lives *inside* #root > .themeProvider > .Layout > div, so
+// `body > header` does NOT match. Target <header> directly.
 export const startpageGoogleCSS = `
-  /* Force dark background matching Google */
+  /* ---------- Page background ---------- */
   html,
-  body {
+  body,
+  #root,
+  .themeProvider,
+  .Layout,
+  main,
+  [class*="e6rco0f0"] {
     background: ${c.bg} !important;
     color: ${c.text} !important;
   }
 
-  /* Search bar pill */
-  .search-form-container {
-    background: ${c.searchBarBg} !important;
-    border-color: transparent !important;
-    border-radius: ${s.searchBarRadiusPx}px !important;
+  /* ---------- Top header band ---------- */
+  /* The SERP header sits at the top and is white by default. Force the
+     same dark bg as the body and add a 1px bottom border. */
+  header,
+  [class*="e1fgh61o0"],
+  .header-inner-container,
+  .mobile-nav,
+  .mobile-nav-logo,
+  .top-nav-container,
+  .hamburger-menu-app-promo {
+    background: ${c.bg} !important;
+    background-color: ${c.bg} !important;
+    border-color: ${c.cardBorder} !important;
+  }
+  header,
+  [class*="e1fgh61o0"] {
+    border-bottom: 1px solid ${c.cardBorder} !important;
     box-shadow: none !important;
   }
-  .search-form-container:hover {
+
+  /* ---------- Search bar pill ---------- */
+  /* The visual pill is .search-form-container (with emotion label
+     e1vne5t50). It currently has white bg + a light border. Replace with
+     Google's dark pill. The form input lives inside it. */
+  .search-form-container,
+  [class*="e1vne5t50"],
+  .search-form-relative-container > div {
+    background: ${c.searchBarBg} !important;
+    background-color: ${c.searchBarBg} !important;
+    border: 1px solid transparent !important;
+    border-radius: ${s.searchBarRadiusPx}px !important;
+    box-shadow: none !important;
+    color: ${c.inputText} !important;
+  }
+  .search-form-container:hover,
+  [class*="e1vne5t50"]:hover {
     background: ${c.searchBarBgHover} !important;
   }
-  .search-form-container:focus-within {
+  .search-form-container:focus-within,
+  [class*="e1vne5t50"]:focus-within {
     background: ${c.searchBarBgFocused} !important;
     box-shadow: 0 4px 12px rgba(23, 23, 23, .9) !important;
   }
-  .search-form-container form {
+  .search-form-form {
+    background: transparent !important;
     min-height: ${s.searchBarHeightPx}px !important;
   }
   .search-form-input,
-  input[name="query"] {
+  input[name="query"],
+  .search-form-container input,
+  .search-form-container input[type="text"] {
+    background: transparent !important;
+    color: ${c.inputText} !important;
     font-family: ${f.display} !important;
     font-size: ${s.inputPx}px !important;
-    color: ${c.inputText} !important;
-    background: transparent !important;
+    border: none !important;
+  }
+  .search-form-container input::placeholder,
+  .search-form-input::placeholder {
+    color: ${c.placeholder} !important;
+  }
+  /* The x-btn divider line between input and search button */
+  .x-btn-container {
+    border-right-color: ${c.cardBorder} !important;
   }
 
-  /* Result block */
-  .result {
-    background: transparent !important;
-    margin-bottom: ${s.resultMarginBottomPx}px !important;
-    max-width: ${s.resultMaxWidthPx}px !important;
-    padding: 0 !important;
+  /* ---------- Hamburger drawer ---------- */
+  .hamburger-drawer,
+  .hamburger-drawer-content {
+    background: ${c.bg} !important;
+    color: ${c.text} !important;
+    border-left-color: ${c.cardBorder} !important;
   }
-
-  /* Title */
-  .wgl-title,
-  .result-title .wgl-title {
-    font-family: ${f.display} !important;
-    font-size: ${s.titlePx}px !important;
-    font-weight: 400 !important;
-    line-height: ${s.titleLineHeightPx}px !important;
-    color: ${c.link} !important;
-  }
-  .result-link:visited .wgl-title {
-    color: ${c.linkVisited} !important;
-  }
-
-  /* Site name */
-  .wgl-site-title,
-  .wgl-site-title .link-text {
-    font-family: ${f.display} !important;
-    font-size: ${s.sitePx}px !important;
-    color: ${c.siteName} !important;
-  }
-
-  /* URL row */
-  .wgl-display-url,
-  .wgl-display-url .link-text,
-  .wgl-display-url .link-text * {
-    font-family: ${f.body} !important;
-    font-size: ${s.sitePathPx}px !important;
-    color: ${c.cite} !important;
-  }
-
-  /* Snippet */
-  .description {
-    font-family: ${f.body} !important;
-    font-size: ${s.snippetPx}px !important;
-    line-height: ${s.snippetLineHeight} !important;
+  .hamburger-subsection-title {
     color: ${c.textMuted} !important;
   }
-
-  /* Hide "Visit in Anonymous View" to match Google's clean look.
-     Remove this rule if you want to keep the anonymous-view affordance. */
-  .anonymous-view-link {
-    display: none !important;
+  .hamburger-drawer a,
+  .hamburger-drawer .link-text {
+    color: ${c.text} !important;
   }
 
-  /* ---------- SERP header chrome ---------- */
-  /* On the SERP, Startpage wraps logo + search bar + tabs in a top <header>.
-     Force the same dark background as the body so the header doesn't sit
-     in its own off-color band. */
-  body > header,
-  .header-inner-container,
-  .mobile-nav,
-  .top-nav-container {
+  /* ---------- Category tabs (All / Images / Videos / News / ...) ---------- */
+  .inline-nav,
+  .inline-nav .categories,
+  .vertical-link-container {
     background: ${c.bg} !important;
   }
-  body > header {
-    border-bottom: 1px solid ${c.cardBorder} !important;
-  }
-
-  /* Category tabs (All / Images / Videos / News / Shopping / Maps).
-     Match Google's underlined tab style. */
   .inline-nav {
-    background: ${c.bg} !important;
     border-bottom: 1px solid ${c.cardBorder} !important;
-  }
-  .inline-nav .categories {
-    display: flex !important;
-  }
-  .inline-nav .vertical-link-container {
-    padding: 0 !important;
   }
   .inline-nav .header-nav-item-button {
-    padding: 0 12px !important;
     background: transparent !important;
+    padding: 0 12px !important;
   }
   .inline-nav .header-nav-item {
     min-height: 48px !important;
@@ -140,15 +140,41 @@ export const startpageGoogleCSS = `
   .inline-nav .header-nav-item:hover .header-nav-item-text {
     color: ${c.text} !important;
   }
+  /* Selected tab (best guess — Startpage doesn't ship aria-current,
+     instead it nests button > whatever in .vertical-link-web for the
+     active one). Style with Google's blue underline. */
+  .vertical-link-web .header-nav-item .header-nav-item-text {
+    color: ${c.link} !important;
+  }
+  .vertical-link-web .header-nav-item {
+    border-bottom-color: ${c.link} !important;
+  }
 
-  /* Google has no "Private Search" affordance — hide Startpage's pill. */
+  /* Filters row */
+  .privacy-indicator-button,
+  .privacy-indicator-content,
+  .privacy-indicator-text {
+    background: transparent !important;
+    color: ${c.textMuted} !important;
+  }
+  .dropdown-select {
+    background: transparent !important;
+    color: ${c.text} !important;
+    border: 1px solid ${c.cardBorder} !important;
+    border-radius: 16px !important;
+  }
+  .dropdown-display {
+    background: ${c.searchBarBgFocused} !important;
+    color: ${c.text} !important;
+    border: 1px solid ${c.cardBorder} !important;
+  }
+
+  /* Hide "Private Search" pill — Google has no equivalent. */
   .private-search-dropdown {
     display: none !important;
   }
 
   /* ---------- Search-suggestion dropdown ---------- */
-  /* The suggestions render inside .search-form-container as a list of
-     .search-suggestion rows. Match Google's autocomplete dropdown look. */
   .suggested-search-container {
     background: ${c.searchBarBgFocused} !important;
     border-radius: 0 0 ${s.searchBarRadiusPx}px ${s.searchBarRadiusPx}px !important;
@@ -169,13 +195,188 @@ export const startpageGoogleCSS = `
     background: ${c.cardBorder} !important;
   }
 
+  /* ---------- Result block ---------- */
+  .result {
+    background: transparent !important;
+    margin-bottom: ${s.resultMarginBottomPx}px !important;
+    max-width: ${s.resultMaxWidthPx}px !important;
+    padding: 0 !important;
+    border: none !important;
+  }
+
+  /* Title — Startpage ships an h2.wgl-title inside an <a> with emotion
+     class. Force Google's blue + size + Google Sans. */
+  .wgl-title,
+  .result-link .wgl-title,
+  .result-title .wgl-title,
+  a.result-link h2,
+  a[class*="result-link"] h2 {
+    font-family: ${f.display} !important;
+    font-size: ${s.titlePx}px !important;
+    font-weight: 400 !important;
+    line-height: ${s.titleLineHeightPx}px !important;
+    color: ${c.link} !important;
+  }
+  a.result-link,
+  a[class*="result-link"],
+  a.result-link:link {
+    color: ${c.link} !important;
+    text-decoration: none !important;
+  }
+  a.result-link:visited,
+  a.result-link:visited .wgl-title,
+  a[class*="result-link"]:visited,
+  a[class*="result-link"]:visited h2 {
+    color: ${c.linkVisited} !important;
+  }
+
+  /* Site name + URL row */
+  .wgl-site-title,
+  .wgl-site-title .link-text {
+    font-family: ${f.display} !important;
+    font-size: ${s.sitePx}px !important;
+    color: ${c.siteName} !important;
+  }
+  .wgl-display-url,
+  .wgl-display-url *,
+  .wgl-display-url .link-text {
+    font-family: ${f.body} !important;
+    font-size: ${s.sitePathPx}px !important;
+    color: ${c.cite} !important;
+  }
+  .favicon-container {
+    background: ${c.bg} !important;
+    border-color: ${c.cardBorder} !important;
+  }
+
+  /* Snippet */
+  .description {
+    font-family: ${f.body} !important;
+    font-size: ${s.snippetPx}px !important;
+    line-height: ${s.snippetLineHeight} !important;
+    color: ${c.textMuted} !important;
+  }
+
+  /* Hide "Visit in Anonymous View" affordance. */
+  .anonymous-view-link {
+    display: none !important;
+  }
+
+  /* ---------- Wikipedia Quick Info card ---------- */
+  .wiki-container,
+  .wiki-qi-container,
+  .wiki-qi-container-see-more,
+  .wiki-qi-container .result,
+  .wiki-qi-container-see-more .result {
+    background: transparent !important;
+    color: ${c.text} !important;
+    border-color: ${c.cardBorder} !important;
+    box-shadow: none !important;
+  }
+  .wiki-qi-container .headline a,
+  .wiki-qi-container-see-more .headline a,
+  .wiki-qi-container .headline h2,
+  .wiki-qi-container-see-more .headline h2 {
+    color: ${c.link} !important;
+    font-family: ${f.display} !important;
+  }
+  .wiki-qi-container .description,
+  .wiki-qi-container-see-more .description,
+  .wiki-qi-container p,
+  .wiki-qi-container-see-more p {
+    color: ${c.textMuted} !important;
+  }
+  .wiki-qi-container .wiki-attr,
+  .wiki-qi-container-see-more .wiki-attr {
+    color: ${c.link} !important;
+  }
+  .see-more-btn {
+    background: transparent !important;
+    color: ${c.text} !important;
+    border-color: ${c.cardBorder} !important;
+  }
+
+  /* ---------- Sidebar ---------- */
+  #sidebar {
+    background: transparent !important;
+  }
+
+  /* ---------- Pagination ---------- */
+  .pagination {
+    background: transparent !important;
+  }
+  .pagination button {
+    background: transparent !important;
+    color: ${c.text} !important;
+    border: 1px solid ${c.cardBorder} !important;
+  }
+  .pagination button[aria-current="page"],
+  .pagination form[aria-label*="current"] button {
+    background: ${c.link} !important;
+    color: #1a1a1a !important;
+    border-color: ${c.link} !important;
+  }
+
+  /* ---------- Feedback widget ---------- */
+  .feedback-button {
+    background: ${c.searchBarBg} !important;
+    color: ${c.text} !important;
+  }
+  .feedback-button__text {
+    color: ${c.text} !important;
+  }
+
+  /* ---------- Support banner (the green/teal "Supporting Startpage is easy" strip) ---------- */
+  /* Hide it on the SERP — Google has nothing like it. */
+  .support-banner {
+    display: none !important;
+  }
+
+  /* ---------- Footer ---------- */
+  footer,
+  [class*="eu3pp1u0"] {
+    background: ${c.bg} !important;
+    color: ${c.text} !important;
+    border-top: 1px solid ${c.cardBorder} !important;
+  }
+  footer a,
+  footer .link-text,
+  footer p,
+  footer span {
+    color: ${c.text} !important;
+  }
+
+  /* ---------- Generic Startpage-blue link override ---------- */
+  /* Startpage uses #2E39B3 for many links. Re-color to Google's link blue
+     where it would otherwise show through (sitelinks, "read more", etc.). */
+  a[class*="result-link"]:link,
+  a[class*="result-link"] h2,
+  .result a:link,
+  .result a:link h2,
+  .sitelink-container a,
+  .sitelink-container a span,
+  .wgl-sitelinks a,
+  .wgl-sitelinks a span {
+    color: ${c.link} !important;
+  }
+  .result a:visited,
+  .result a:visited h2 {
+    color: ${c.linkVisited} !important;
+  }
+
   /* ---------- Body font ---------- */
-  /* Default to Arial across the page so non-result chrome matches the
-     Google body typography. */
   body {
     font-family: ${f.body} !important;
   }
   h1, h2, h3, h4 {
     font-family: ${f.display} !important;
+  }
+
+  /* ---------- Theme-flash mitigation override ---------- */
+  /* Startpage injects an inline <style class="theme-flash-mitigation"> that
+     forces html background to #fff via a media query. We can't kill the
+     inline rule but our id'd <style> tag is appended later, so this wins. */
+  @media (prefers-color-scheme: light) {
+    html { background: ${c.bg} !important; }
   }
 `;

--- a/src/components/google-theme/variants/startpage.ts
+++ b/src/components/google-theme/variants/startpage.ts
@@ -1,0 +1,95 @@
+import { tokens } from "../tokens";
+
+const c = tokens.color;
+const f = tokens.font;
+const s = tokens.size;
+
+// Startpage uses emotion-generated css-* class names but ships stable
+// semantic classes alongside them (.result, .wgl-title, .wgl-site-title,
+// .wgl-display-url, .description). The search form has .search-form-container
+// and input.search-form-input.
+export const startpageGoogleCSS = `
+  /* Force dark background matching Google */
+  html,
+  body {
+    background: ${c.bg} !important;
+    color: ${c.text} !important;
+  }
+
+  /* Search bar pill */
+  .search-form-container {
+    background: ${c.searchBarBg} !important;
+    border-color: transparent !important;
+    border-radius: ${s.searchBarRadiusPx}px !important;
+    box-shadow: none !important;
+  }
+  .search-form-container:hover {
+    background: ${c.searchBarBgHover} !important;
+  }
+  .search-form-container:focus-within {
+    background: ${c.searchBarBgFocused} !important;
+    box-shadow: 0 4px 12px rgba(23, 23, 23, .9) !important;
+  }
+  .search-form-container form {
+    min-height: ${s.searchBarHeightPx}px !important;
+  }
+  .search-form-input,
+  input[name="query"] {
+    font-family: ${f.display} !important;
+    font-size: ${s.inputPx}px !important;
+    color: ${c.inputText} !important;
+    background: transparent !important;
+  }
+
+  /* Result block */
+  .result {
+    background: transparent !important;
+    margin-bottom: ${s.resultMarginBottomPx}px !important;
+    max-width: ${s.resultMaxWidthPx}px !important;
+    padding: 0 !important;
+  }
+
+  /* Title */
+  .wgl-title,
+  .result-title .wgl-title {
+    font-family: ${f.display} !important;
+    font-size: ${s.titlePx}px !important;
+    font-weight: 400 !important;
+    line-height: ${s.titleLineHeightPx}px !important;
+    color: ${c.link} !important;
+  }
+  .result-link:visited .wgl-title {
+    color: ${c.linkVisited} !important;
+  }
+
+  /* Site name */
+  .wgl-site-title,
+  .wgl-site-title .link-text {
+    font-family: ${f.display} !important;
+    font-size: ${s.sitePx}px !important;
+    color: ${c.siteName} !important;
+  }
+
+  /* URL row */
+  .wgl-display-url,
+  .wgl-display-url .link-text,
+  .wgl-display-url .link-text * {
+    font-family: ${f.body} !important;
+    font-size: ${s.sitePathPx}px !important;
+    color: ${c.cite} !important;
+  }
+
+  /* Snippet */
+  .description {
+    font-family: ${f.body} !important;
+    font-size: ${s.snippetPx}px !important;
+    line-height: ${s.snippetLineHeight} !important;
+    color: ${c.textMuted} !important;
+  }
+
+  /* Hide "Visit in Anonymous View" to match Google's clean look.
+     Remove this rule if you want to keep the anonymous-view affordance. */
+  .anonymous-view-link {
+    display: none !important;
+  }
+`;

--- a/src/components/google-theme/variants/startpage.ts
+++ b/src/components/google-theme/variants/startpage.ts
@@ -123,11 +123,11 @@ export const startpageGoogleCSS = `
     background: transparent !important;
     padding: 0 12px !important;
   }
+  /* Keep tabs at Startpage's native height — making them taller pushes the
+     header past its hardcoded 118px offset and crops the filter row below. */
   .inline-nav .header-nav-item {
-    min-height: 48px !important;
     display: flex !important;
     align-items: flex-end !important;
-    padding-bottom: 8px !important;
     border-bottom: 3px solid transparent !important;
   }
   .inline-nav .header-nav-item-text {
@@ -150,7 +150,13 @@ export const startpageGoogleCSS = `
     border-bottom-color: ${c.link} !important;
   }
 
-  /* Filters row */
+  /* Filters row — Startpage ships a hardcoded padding-top: 118px to clear
+     the fixed header. Bump it a touch to absorb any drift from our overrides. */
+  @media (min-width: 990px) {
+    #filters-container {
+      padding-top: 132px !important;
+    }
+  }
   .privacy-indicator-button,
   .privacy-indicator-content,
   .privacy-indicator-text {

--- a/src/content.ts
+++ b/src/content.ts
@@ -100,5 +100,5 @@ if (site === "brave") {
   ];
 
   runAll(ddgOps);
-  observeDOMChanges([checkStorage, addDuckDuckNewSettings]);
+  observeDOMChanges([applyGoogleTheme, checkStorage, addDuckDuckNewSettings]);
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -21,6 +21,7 @@ import { addBraveNewSettingsSidePanel } from "./components/email/email-settings/
 import { addDuckDuckNewSettings } from "./components/email/email-settings/variants/duckduckgo";
 import { addStartpageNewSettings } from "./components/email/email-settings/variants/startpage";
 import { addCssColorVariables } from "./components/stylesheets";
+import { applyGoogleTheme } from "./components/google-theme";
 import {
   getSite,
   removeElementByQuery,
@@ -42,6 +43,7 @@ const site = getSite();
 if (site === "brave") {
   const braveOps: Array<() => void> = [
     addCssColorVariables,
+    applyGoogleTheme,
     removeElementByQuery.bind(null, ".subutton-wrapper"),
     removeElementByQuery.bind(null, "footer"),
     replaceBraveToGoogleLogo,
@@ -72,6 +74,7 @@ if (site === "brave") {
   // button, settings panel) are wired here but live behind TODO markers
   // until the host DOM has been inspected and selectors confirmed.
   const startpageOps: Array<() => void> = [
+    applyGoogleTheme,
     replaceFavicon,
     changeStartpageTitle,
     replaceStartpageToGoogleLogo,
@@ -84,6 +87,7 @@ if (site === "brave") {
   observeDOMChanges(startpageOps);
 } else {
   const ddgOps: Array<() => void> = [
+    applyGoogleTheme,
     replaceDuckDuckGoToGoogleLogo,
     removeElementByQuery.bind(null, "#features"),
     removeElementByQuery.bind(null, ".homepage-cta-section_scrollCta__HuSCL"),


### PR DESCRIPTION
## Summary

Applies a unified Google-look across all three engines' SERPs: dark palette, Google Sans titles, Arial body, 22px titles, 14px snippets, 26px pill search bar, 30px result spacing.

## How it's structured

- **`google-theme/tokens.ts`** — single source of truth for colors/fonts/sizes, extracted from a live Google SERP
- **`google-theme/variants/{brave,duckduckgo,startpage}.ts`** — per-engine CSS string built from tokens
- **`google-theme/index.ts`** — id-guarded `<style>` injector, observer-safe (re-runs on every DOM mutation are cheap no-ops)
- **`content.ts`** — `applyGoogleTheme` registered as an op on all three sites, so it survives SPA route changes

## Selector choices

| Engine | Stable selectors used |
|---|---|
| Brave | `.RNNXgb`, `.gLFyf`, `.snippet[data-type]`, `.snippet-description` (Brave Search uses the same class names as Google itself) |
| DuckDuckGo | `data-testid="result"`, `data-layout="organic"`, `data-testid="result-title-a"`, `data-testid="result-extras-url-link"`, `data-result="snippet"` — DDG ships React with hashed class names that churn between builds, so data-* is the only safe surface |
| Startpage | `.result`, `.wgl-title`, `.wgl-site-title`, `.wgl-display-url`, `.description`, `.search-form-container` — these are stable semantic classes alongside the emotion `css-*` hashes |

## Cosmetic decisions

- DDG: hides the 3-dot context menu (`button[aria-haspopup="menu"]`) and the side-image (`a[data-srp-el-jm-ea]`) for visual parity with Google's clean rows
- Startpage: hides the "Visit in Anonymous View" link for the same reason. Easy to revert by removing the `.anonymous-view-link { display: none }` rule

## Test plan

- [x] `bun run build:all` clean (+9 kB to content.js, ~2 kB gzipped)
- [ ] Brave SERP: titles render in Google Sans blue at 22px; snippets in Arial gray; search bar pill matches Google
- [ ] DuckDuckGo SERP: same; 3-dot menu and side image hidden; layout matches Google's row order
- [ ] Startpage SERP: same; Anonymous View link hidden; site name / URL / title / snippet stack matches Google
- [ ] No regressions on home pages (search bar styling applies there too)

## Known limitations

- DDG / Startpage have richer rich-result types (knowledge panels, video carousels, news). This PR only restyles **organic web results** — other result types will fall back to engine defaults until similar selector work is done for them.
- Bottom of every SERP usually has sponsored/ads/AI-overview cards. Those keep their engine's native styling.